### PR TITLE
added ascii qrcode support

### DIFF
--- a/pretexts/mfa/qrcode_ascii_email.html
+++ b/pretexts/mfa/qrcode_ascii_email.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+    <div style="background-color:#eee;padding:10px 20px;">
+        <h2 style="font-family:Georgia, 'Times New Roman', Times, serif; color: #454349;">Microsoft Authenticator Update Needed</h2>
+    </div>
+    <div style="padding:20px 0px">
+        <div style="height: 500px;width:400px">
+            <p> Your Microsoft Authenticator token has expired. Please scan the QR code below to generate a new
+                device code for your Microsoft Authenticator App.</p>
+            <p> The code will be emailed to you, and you should enter it at
+                <a
+                    href="https://login.microsoftonline.com/common/oauth2/deviceauth">https://login.microsoftonline.com/common/oauth2/deviceauth</a>
+            </p>
+            <div style="word-spacing:normal;">
+            <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%%;">
+                <tbody>
+                    <tr>
+                        <td align='center' style='mso-line-height-rule: exactly;line-height: 90%%;font-size: 1.8pt; font-family: "Courier New"; color: black'>
+                            %s
+                        </td>                    
+                    </tr>
+                </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/settings.config
+++ b/settings.config
@@ -12,6 +12,7 @@ SQUAREPHISH_ENDPOINT = "/broker_auth"                                           
 FROM_EMAIL           = "admin@square.phish"                                                     # Default FROM address when sending an email
 SUBJECT              = "ACTION REQUIRED:  Microsoft Office 365 Token has Expired"               # Default SUBJECT when sending an email, defauled to an MFA pretext
 EMAIL_TEMPLATE       = "pretexts/broker_auth/qrcode_email.html"                                 # Email body template for QR code email to victim
+QRCODE_ASCII         = "false"                                                                  # Send qrcode as ascii art
 
 [SERVER]
 PORT                 = 8443


### PR DESCRIPTION
Added support for ascii-based qrcode.

If you modify the settings.config as follow, you can send ascii-based qrcode to victims.

```
EMAIL_TEMPLATE       = "pretexts/mfa/qrcode_ascii_email.html"                                 # Email body template for QR code email to victim
QRCODE_ASCII         = "true"                                                                  # Send qrcode as ascii art
```